### PR TITLE
Fix next-post nav footer urls

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -31,7 +31,7 @@ layout: page
         <div class="wrapper" id="right">
           <small>{{page.next.date | date: "%b %-d, %Y"}} <b>Next</b></small>
           <br>
-          <a class="no-hov" href="{{ page.previous.url | prepend: site.baseurl }}">{{page.next.title}} &raquo;</a>
+          <a class="no-hov" href="{{ page.next.url | prepend: site.baseurl }}">{{page.next.title}} &raquo;</a>
         </div>
 		{% endif %}
 		</div>


### PR DESCRIPTION
The links to the next post showed the right information but were actually linking to the previous post due to a typo in the URL template (`page.previous.url` instead of `page.next.url`). This should patch that. Tested on GH pages on my fork.